### PR TITLE
BUG/BACKUPRRD=false is wrong. It backups rdd all the time.

### DIFF
--- a/pfsense2-backup.sh
+++ b/pfsense2-backup.sh
@@ -226,11 +226,11 @@ POSTDATA="${POSTDATA}&__csrf_magic=${URL_CSRF}"
 
 ### RRDs
 if [ "${BACKUPRRD,,}" == "true" ] ; then
-	logger -p user.info -t "${APPNAME}" -- "Enabled RRD backups" 
-	POSTDATA="${POSTDATA}&donotbackuprrd=on"
-else 
-	logger -p user.info -t "${APPNAME}" -- "Disabled RRD backups"
-fi 
+        logger -p user.info -t "${APPNAME}" -- "Enabled RRD backups"
+else
+        logger -p user.info -t "${APPNAME}" -- "Disabled RRD backups"
+        POSTDATA="${POSTDATA}&donotbackuprrd=yes"
+fi
 ### Encryption
 if [ ! -z "${ENCRYPTPASS}" ] ; then
 	logger -p user.info -t "${APPNAME}" -- "Encrypting backup"


### PR DESCRIPTION
Iam on 2.4.3-RELEASE.

The setting BACKUPRRD=false is wrong. It backups rdd all the time.

https://github.com/hydrian/pfsense-backups/issues/17